### PR TITLE
Issue 36: Initial changes for node-firefox as distribution module

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.sw?
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,61 @@
 # node-firefox
 
-*node.js modules for interacting with Firefox via the [DevTools](https://developer.mozilla.org/en-US/docs/Tools) [remote protocol](https://wiki.mozilla.org/Remote_Debugging_Protocol).*
+As an overall project, node-firefox is a family of modules made for interacting
+with Firefox via the [DevTools][] [Remote Protocol][].
+
+As a module, `node-firefox` serves as a table of contents for the rest of the
+modules in the node-firefox family. 
+
+[DevTools]: https://developer.mozilla.org/en-US/docs/Tools
+[Remote Protocol]: https://wiki.mozilla.org/Remote_Debugging_Protocol
+
+## Installation
+
+### npm
+
+```bash
+npm install node-firefox
+```
+
+### From git
+
+```bash
+git clone https://github.com/mozilla/node-firefox.git
+cd node-firefox
+npm install
+```
+
+If you want to update later on:
+
+```bash
+cd node-firefox
+git pull origin master
+npm install
+```
+
+## Usage
+
+Using `require('node-firefox')` yields an object with properties that contain
+instances of all the other modules in the `node-firefox` family installed as
+dependencies.
+
+For example:
+
+```javascript
+> var firefox = require('node-firefox');
+> Object.keys(firefox)
+[ 'findPorts',
+  'findDevices',
+  'forwardPorts',
+  'findSimulators',
+  'startSimulator',
+  'connect',
+  'findApp',
+  'installApp',
+  'uninstallApp',
+  'launchApp',
+  'reloadCss' ]
+```
 
 ## Some of our grand goals
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  findPorts: require('node-firefox-find-ports'),
+  findDevices: require('node-firefox-find-devices'),
+  forwardPorts: require('node-firefox-forward-ports'),
+  findSimulators: require('node-firefox-find-simulators'),
+  startSimulator: require('node-firefox-start-simulator'),
+  connect: require('node-firefox-connect'),
+  findApp: require('node-firefox-find-app'),
+  installApp: require('node-firefox-install-app'),
+  uninstallApp: require('node-firefox-uninstall-app'),
+  launchApp: require('node-firefox-launch-app'),
+  reloadCss: require('node-firefox-reload-css')
+};

--- a/package.json
+++ b/package.json
@@ -21,5 +21,18 @@
     "gulp": "^3.8.11",
     "node-firefox-build-tools": "^0.2.0",
     "teacher": "0.0.1"
+  },
+  "dependencies": {
+    "node-firefox-connect": "^1.2.0",
+    "node-firefox-find-app": "^1.1.0",
+    "node-firefox-find-devices": "^1.0.0",
+    "node-firefox-find-ports": "^1.2.0",
+    "node-firefox-find-simulators": "^1.3.0",
+    "node-firefox-forward-ports": "^1.0.0",
+    "node-firefox-install-app": "^1.1.0",
+    "node-firefox-launch-app": "^1.1.0",
+    "node-firefox-reload-css": "^1.2.0",
+    "node-firefox-start-simulator": "^1.3.1",
+    "node-firefox-uninstall-app": "^1.1.0"
   }
 }


### PR DESCRIPTION
Just an initial set of small changes to use node-firefox as a distribution module.

Thinking of expanding this to also come along with a CLI tool, but maybe itself as a separate repo. But, wanted to see how just adding the "table of contents" module worked at first.